### PR TITLE
Add an autotools project

### DIFF
--- a/ExternData/Resources/BuildProjects/autotools/Makefile.am
+++ b/ExternData/Resources/BuildProjects/autotools/Makefile.am
@@ -1,0 +1,57 @@
+lib_LTLIBRARIES = libbsxml-json.la libED_INIFile.la libED_JSONFile.la libED_MATFile.la libED_XLSFile.la libED_XLSXFile.la libED_XMLFile.la libexpat.la libzlib.la
+
+libbsxml_json_la_SOURCES = \
+	../../C-Sources/bsxml-json/array.c \
+	../../C-Sources/bsxml-json/bsjson.c \
+	../../C-Sources/bsxml-json/bsxml.c
+
+libED_INIFile_la_SOURCES = \
+	../../C-Sources/minIni.c \
+	../../C-Sources/ED_INIFile.c
+
+libED_JSONFile_la_SOURCES = \
+	../../C-Sources/ED_JSONFile.c
+
+libED_MATFile_la_SOURCES = \
+	../../C-Sources/ED_MATFile.c \
+	../../C-Sources/ModelicaMatIO.c
+
+libED_XLSFile_la_SOURCES = \
+	../../C-Sources/libxls/src/endian.c \
+	../../C-Sources/libxls/src/ole.c \
+	../../C-Sources/libxls/src/xls.c \
+	../../C-Sources/libxls/src/xlstool.c \
+	../../C-Sources/ED_XLSFile.c
+
+libED_XLSXFile_la_SOURCES = \
+	../../C-Sources/minizip/ioapi.c \
+	../../C-Sources/minizip/miniunz.c \
+	../../C-Sources/minizip/unzip.c \
+	../../C-Sources/ED_XLSXFile.c
+
+libED_XMLFile_la_SOURCES = \
+	../../C-Sources/ED_XMLFile.c
+
+libexpat_la_SOURCES = \
+	../../C-Sources/expat/lib/xmlparse.c \
+	../../C-Sources/expat/lib/xmlrole.c \
+	../../C-Sources/expat/lib/xmltok.c \
+	../../C-Sources/expat/lib/xmltok_impl.c \
+	../../C-Sources/expat/lib/xmltok_ns.c
+
+libzlib_la_SOURCES = \
+	../../C-Sources/zlib/adler32.c \
+	../../C-Sources/zlib/compress.c \
+	../../C-Sources/zlib/crc32.c \
+	../../C-Sources/zlib/deflate.c \
+	../../C-Sources/zlib/gzclose.c \
+	../../C-Sources/zlib/gzlib.c \
+	../../C-Sources/zlib/gzread.c \
+	../../C-Sources/zlib/gzwrite.c \
+	../../C-Sources/zlib/infback.c \
+	../../C-Sources/zlib/inffast.c \
+	../../C-Sources/zlib/inflate.c \
+	../../C-Sources/zlib/inftrees.c \
+	../../C-Sources/zlib/trees.c \
+	../../C-Sources/zlib/uncompr.c \
+	../../C-Sources/zlib/zutil.c

--- a/ExternData/Resources/BuildProjects/autotools/README
+++ b/ExternData/Resources/BuildProjects/autotools/README
@@ -1,0 +1,21 @@
+For more detailed installation instructions:
+./autogen.sh (generates the project)
+less INSTALL
+# Default: Build only shared libraries with everything included.
+./configure
+# To add static libraries (not as compatible)
+./configure --enable-static
+# For an entirely static library
+./configure --enable-static --disable-shared --libdir=/path/to/Modelica/Resources/Library/linux64
+make
+sudo make install
+sudo make uninstall
+
+Note that special care has to be taken if there is a space in the path (e.g. /path/to/Modelica 3.2.2/Resources/Library/linux32).
+GNU tools, libtool in particular, cannot handle paths with spaces in them (which is one of the reasons you should never install MinGW in a path with spaces).
+In this case, there are two main workarounds:
+* Temporarily move the directory to one without spaces, and moving it back after make install.
+* Manually copying the files instead of make install: cp .libs/* ../Library/linux32
+
+Minimal files needed to compile on Unix (requires autotools installed):
+ autogen.sh, configure.ac, Makefile.am, README

--- a/ExternData/Resources/BuildProjects/autotools/autogen.sh
+++ b/ExternData/Resources/BuildProjects/autotools/autogen.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Not a proper package; will be added somewhere else anyway
+mkdir -p m4 # Needed in OSX
+for f in AUTHORS ChangeLog COPYING README NEWS; do
+  test -f "$f" || touch "$f"
+done
+autoreconf --force --install

--- a/ExternData/Resources/BuildProjects/autotools/configure.ac
+++ b/ExternData/Resources/BuildProjects/autotools/configure.ac
@@ -1,0 +1,26 @@
+dnl Init
+AC_PREREQ([2.63])
+AC_INIT([ExternData],[2.0.0-dev],[https://github.com/tbeu/ExternData/issues],[ExternData],[https://github.com/tbeu/ExternData])
+
+AM_INIT_AUTOMAKE([subdir-objects])
+AC_CONFIG_MACRO_DIR([m4])
+
+if test -z "$CFLAGS"; then
+  CFLAGS="-Os"
+fi
+
+AC_LANG([C])
+AC_PROG_CC
+AC_PROG_CPP
+AC_PROG_MAKE_SET
+LT_INIT([disable-shared])
+
+CPPFLAGS="$CPPFLAGS -DHAVE_MEMMOVE=1 -DHAVE_ZLIB=1 -DNDEBUG -I../../C-Sources/bsxml-json -I../../C-Sources/ -I../../C-Sources/expat/lib -I../../C-Sources/libxls/include -I../../C-Sources/minizip -I../../C-Sources/zlib"
+
+if test "$libdir" = '${exec_prefix}/lib'; then
+  # It is hard to detect where to put the libraries if we cross-compile. Let the tool decide where to put it.
+  # Use Resources/Library/ as the default.
+  libdir=`pwd`/../../Library/
+fi
+
+AC_OUTPUT([Makefile])


### PR DESCRIPTION
This was requested in issue #9

The project mimics the Makefile, except:
- It uses -Os since it almost halves the size of libexpat.a
- It installs into Library/ by default (use ./configure --libdir to set
  your own directory)
